### PR TITLE
Use grafana unit support to humanize seconds axis

### DIFF
--- a/grafana/grafana.json
+++ b/grafana/grafana.json
@@ -98,8 +98,8 @@
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": "Seconds",
+              "format": "s",
+              "label": "",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -253,8 +253,8 @@
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": "Seconds",
+              "format": "s",
+              "label": "",
               "logBase": 1,
               "max": null,
               "min": null,


### PR DESCRIPTION
Grafana support axis units to normalize the display of common formats,
so you can use that to make sure that grafana display seconds in a human
readable format using a appropriate unit of time (ms, s, m or h)

Sample:
![Image](https://www.dropbox.com/s/90th5c8taj35xuz/Screenshot%202017-04-11%2011.15.01.png?dl=1)