### PR TITLE
Added filtering by source to the grafana dashboard

### DIFF
--- a/grafana/grafana.json
+++ b/grafana/grafana.json
@@ -1,8 +1,8 @@
 {
   "__inputs": [
     {
-      "name": "DS_SWARM",
-      "label": "Swarm",
+      "name": "DS_SWARM-DATASOURCE",
+      "label": "swarm-datasource",
       "description": "",
       "type": "datasource",
       "pluginId": "prometheus",
@@ -14,7 +14,7 @@
       "type": "grafana",
       "id": "grafana",
       "name": "Grafana",
-      "version": "4.1.1"
+      "version": "4.4.3"
     },
     {
       "type": "panel",
@@ -47,7 +47,9 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_SWARM}",
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_SWARM-DATASOURCE}",
           "fill": 1,
           "id": 1,
           "legend": {
@@ -68,16 +70,19 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "http_rtt_gauge_seconds",
+              "expr": "http_rtt_gauge_seconds{instance=~\"$source\",target=~\".*\"}",
+              "format": "time_series",
               "intervalFactor": 2,
+              "legendFormat": "{{instance}} -> {{target}}",
               "metric": "http_rtt_gauge_seconds",
               "refId": "A",
-              "step": 4
+              "step": 120
             }
           ],
           "thresholds": [],
@@ -91,6 +96,7 @@
           },
           "type": "graph",
           "xaxis": {
+            "buckets": null,
             "mode": "time",
             "name": null,
             "show": true,
@@ -118,7 +124,9 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_SWARM}",
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_SWARM-DATASOURCE}",
           "fill": 1,
           "id": 5,
           "legend": {
@@ -139,16 +147,19 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "http_timeout_gauge_boolean",
+              "expr": "http_timeout_gauge_boolean{instance=~\"$source\",target=~\".*\"}",
+              "format": "time_series",
               "intervalFactor": 2,
+              "legendFormat": "{{instance}} -> {{target}}",
               "metric": "http_timeout_gauge_boolean",
               "refId": "A",
-              "step": 4
+              "step": 120
             }
           ],
           "thresholds": [],
@@ -162,6 +173,7 @@
           },
           "type": "graph",
           "xaxis": {
+            "buckets": null,
             "mode": "time",
             "name": null,
             "show": true,
@@ -173,7 +185,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -181,7 +193,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -201,7 +213,9 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_SWARM}",
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_SWARM-DATASOURCE}",
           "fill": 1,
           "id": 3,
           "legend": {
@@ -222,17 +236,19 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "udp_rtt_gauge_seconds",
+              "expr": "udp_rtt_gauge_seconds{instance=~\"$source\",target=~\".*\"}",
+              "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "",
+              "legendFormat": "{{instance}} -> {{target}}",
               "metric": "udp_rtt_gauge_seconds",
               "refId": "A",
-              "step": 4
+              "step": 120
             }
           ],
           "thresholds": [],
@@ -246,6 +262,7 @@
           },
           "type": "graph",
           "xaxis": {
+            "buckets": null,
             "mode": "time",
             "name": null,
             "show": true,
@@ -273,13 +290,18 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_SWARM}",
-          "description": "A packet is considered lost if the UDP ping sender does not receive an acknowledgement from the remote server. Each counted \"lost packet\" occurence here indicates that either one or both actual UDP packets were lost.",
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_SWARM-DATASOURCE}",
+          "decimals": null,
+          "description": "A packet is considered lost if the UDP ping sender does not receive an acknowledgement from the remote server. Each counted \"lost packet\" occurrence here indicates that either one or both actual UDP packets were lost.",
           "fill": 1,
           "id": 4,
           "legend": {
             "avg": false,
             "current": false,
+            "hideEmpty": false,
+            "hideZero": true,
             "max": false,
             "min": false,
             "show": true,
@@ -295,16 +317,20 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 6,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "udp_packet_loss_gauge_boolean",
+              "expr": "udp_packet_loss_gauge_boolean{instance=~\"$source\",target=~\".*\"}",
+              "format": "time_series",
+              "interval": "",
               "intervalFactor": 2,
+              "legendFormat": "{{instance}} -> {{target}}",
               "metric": "udp_packet_loss_gauge_boolean",
               "refId": "A",
-              "step": 4
+              "step": 120
             }
           ],
           "thresholds": [],
@@ -312,16 +338,19 @@
           "timeShift": null,
           "title": "UDP Packet Loss",
           "tooltip": {
-            "shared": true,
+            "shared": false,
             "sort": 0,
             "value_type": "individual"
           },
           "type": "graph",
           "xaxis": {
+            "buckets": null,
             "mode": "time",
             "name": null,
             "show": true,
-            "values": []
+            "values": [
+              "total"
+            ]
           },
           "yaxes": [
             {
@@ -329,7 +358,7 @@
               "label": "Lost Packets",
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             },
             {
@@ -337,7 +366,7 @@
               "label": null,
               "logBase": 1,
               "max": null,
-              "min": null,
+              "min": "0",
               "show": true
             }
           ]
@@ -357,7 +386,9 @@
         {
           "aliasColors": {},
           "bars": false,
-          "datasource": "${DS_SWARM}",
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": "${DS_SWARM-DATASOURCE}",
           "fill": 1,
           "id": 2,
           "legend": {
@@ -378,17 +409,19 @@
           "points": false,
           "renderer": "flot",
           "seriesOverrides": [],
+          "spaceLength": 10,
           "span": 12,
           "stack": false,
           "steppedLine": false,
           "targets": [
             {
-              "expr": "icmp_rtt_gauge_seconds",
+              "expr": "icmp_rtt_gauge_seconds{instance=~\"$source\",target=~\".*\"}",
+              "format": "time_series",
               "intervalFactor": 2,
-              "legendFormat": "",
+              "legendFormat": "{{instance}} -> {{target}}",
               "metric": "icmp_rtt_gauge_seconds",
               "refId": "A",
-              "step": 2
+              "step": 60
             }
           ],
           "thresholds": [],
@@ -402,6 +435,7 @@
           },
           "type": "graph",
           "xaxis": {
+            "buckets": null,
             "mode": "time",
             "name": null,
             "show": true,
@@ -409,8 +443,8 @@
           },
           "yaxes": [
             {
-              "format": "short",
-              "label": "Seconds",
+              "format": "s",
+              "label": "",
               "logBase": 1,
               "max": null,
               "min": null,
@@ -439,7 +473,28 @@
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "allValue": null,
+        "current": {},
+        "datasource": "${DS_SWARM-DATASOURCE}",
+        "hide": 0,
+        "includeAll": true,
+        "label": "Source",
+        "multi": true,
+        "name": "source",
+        "options": [],
+        "query": "label_values(instance)",
+        "refresh": 1,
+        "regex": "/^(?!0\\.0\\.0\\.0.*)/",
+        "sort": 0,
+        "tagValuesQuery": "",
+        "tags": [],
+        "tagsQuery": "",
+        "type": "query",
+        "useTags": false
+      }
+    ]
   },
   "time": {
     "from": "now-30m",
@@ -472,5 +527,5 @@
   },
   "timezone": "utc",
   "title": "Network Benchmark Tool",
-  "version": 1
+  "version": 2
 }


### PR DESCRIPTION
In the original dashboard there isn't the option to filter by `source` (instance). I've added a filter to the dashboard for it.

I could add another filter by `target` but it's a bit messy because in the TCP connections the targets appear with `http://` and the filtering expression is complex.

I suggest to remove the `http://` from the `target` value in TCP connections if possible.